### PR TITLE
Update hakrawler.go

### DIFF
--- a/hakrawler.go
+++ b/hakrawler.go
@@ -19,280 +19,386 @@ import (
 	"github.com/gocolly/colly/v2"
 )
 
+// Result stores the output fields for each found URL.
 type Result struct {
 	Source string
 	URL    string
 	Where  string
 }
 
+// Headers from the command line flag, stored in a map for easy usage by Colly.
 var headers map[string]string
 
-// Thread safe map
+// Thread-safe map for uniqueness checks.
 var sm sync.Map
 
 func main() {
 	inside := flag.Bool("i", false, "Only crawl inside path")
-	threads := flag.Int("t", 8, "Number of threads to utilise.")
+	threads := flag.Int("t", 8, "Number of threads to utilize.")
 	depth := flag.Int("d", 2, "Depth to crawl.")
 	maxSize := flag.Int("size", -1, "Page size limit, in KB.")
 	insecure := flag.Bool("insecure", false, "Disable TLS verification.")
 	subsInScope := flag.Bool("subs", false, "Include subdomains for crawling.")
-	showJson := flag.Bool("json", false, "Output as JSON.")
-	showSource := flag.Bool("s", false, "Show the source of URL based on where it was found. E.g. href, form, script, etc.")
-	showWhere := flag.Bool("w", false, "Show at which link the URL is found.")
-	rawHeaders := flag.String(("h"), "", "Custom headers separated by two semi-colons. E.g. -h \"Cookie: foo=bar;;Referer: http://example.com/\" ")
-	unique := flag.Bool(("u"), false, "Show only unique urls.")
-	proxy := flag.String(("proxy"), "", "Proxy URL. E.g. -proxy http://127.0.0.1:8080")
-	timeout := flag.Int("timeout", -1, "Maximum time to crawl each URL from stdin, in seconds.")
+	showJSON := flag.Bool("json", false, "Output results as JSON.")
+	showSource := flag.Bool("s", false, "Show the source of URL (e.g. href, form, script).")
+	showWhere := flag.Bool("w", false, "Show from which link the URL was found.")
+	rawHeaders := flag.String("h", "", "Custom headers separated by double semicolons. e.g. -h \"Cookie: foo=bar;;Referer: http://example.com/\" ")
+	uniqueOnly := flag.Bool("u", false, "Show only unique URLs.")
+	proxy := flag.String("proxy", "", "Proxy URL. e.g. -proxy http://127.0.0.1:8080")
+	timeout := flag.Int("timeout", -1, "Max time to crawl each URL from stdin, in seconds. -1 means no timeout.")
 	disableRedirects := flag.Bool("dr", false, "Disable following HTTP redirects.")
 
 	flag.Parse()
 
-	if *proxy != "" {
-		os.Setenv("PROXY", *proxy)
+	// Validate the number of threads
+	if *threads < 1 {
+		fmt.Fprintln(os.Stderr, "Invalid number of threads, resetting to default (8).")
+		*threads = 8
 	}
-	proxyURL, _ := url.Parse(os.Getenv("PROXY"))
 
-	// Convert the headers input to a usable map (or die trying)
-	err := parseHeaders(*rawHeaders)
-	if err != nil {
+	// Parse and validate custom headers (if any).
+	if err := parseHeaders(*rawHeaders); err != nil {
 		fmt.Fprintln(os.Stderr, "Error parsing headers:", err)
 		os.Exit(1)
 	}
 
-	// Check for stdin input
-	stat, _ := os.Stdin.Stat()
-	if (stat.Mode() & os.ModeCharDevice) != 0 {
-		fmt.Fprintln(os.Stderr, "No urls detected. Hint: cat urls.txt | hakrawler")
+	// Prepare proxy config if provided.
+	if *proxy != "" {
+		if err := os.Setenv("PROXY", *proxy); err != nil {
+			fmt.Fprintln(os.Stderr, "Failed to set PROXY environment variable:", err)
+			os.Exit(1)
+		}
+	}
+
+	proxyURL, err := url.Parse(os.Getenv("PROXY"))
+	if err != nil && *proxy != "" {
+		fmt.Fprintln(os.Stderr, "Invalid proxy URL:", err)
 		os.Exit(1)
 	}
 
+	// Check for STDIN input to avoid waiting on an empty pipe.
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error reading Stdin:", err)
+		os.Exit(1)
+	}
+	if (stat.Mode() & os.ModeCharDevice) != 0 {
+		fmt.Fprintln(os.Stderr, "No URLs detected on stdin. Hint: cat urls.txt | hakrawler")
+		os.Exit(1)
+	}
+
+	// Prepare channel for results.
 	results := make(chan string, *threads)
+
+	// Goroutine to read from stdin and process each URL.
 	go func() {
-		// get each line of stdin, push it to the work channel
-		s := bufio.NewScanner(os.Stdin)
-		for s.Scan() {
-			url := s.Text()
-			hostname, err := extractHostname(url)
-			if err != nil {
-				log.Println("Error parsing URL:", err)
+		sc := bufio.NewScanner(os.Stdin)
+		for sc.Scan() {
+			urlToVisit := sc.Text()
+			if urlToVisit == "" {
 				continue
 			}
 
-			allowed_domains := []string{hostname}
-			// if "Host" header is set, append it to allowed domains
+			hostname, err := extractHostname(urlToVisit)
+			if err != nil {
+				log.Println("[Error] Invalid URL:", err, "| Input was:", urlToVisit)
+				continue
+			}
+
+			// Allowed domains (initially includes the main hostname).
+			allowedDomains := []string{hostname}
+
+			// If "Host" header is set, append it to allowed domains.
 			if headers != nil {
-				if val, ok := headers["Host"]; ok {
-					allowed_domains = append(allowed_domains, val)
+				if hostVal, ok := headers["Host"]; ok && hostVal != "" {
+					allowedDomains = append(allowedDomains, hostVal)
 				}
 			}
 
-			// Instantiate default collector
-			c := colly.NewCollector(
-				// default user agent header
-				colly.UserAgent("Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0"),
-				// set custom headers
-				colly.Headers(headers),
-				// limit crawling to the domain of the specified URL
-				colly.AllowedDomains(allowed_domains...),
-				// set MaxDepth to the specified depth
-				colly.MaxDepth(*depth),
-				// specify Async for threading
-				colly.Async(true),
+			// Create a Colly collector with the user-specified options.
+			c := createCollector(
+				allowedDomains,
+				*depth,
+				*maxSize,
+				*insecure,
+				proxyURL,
+				*threads,
+				*subsInScope,
+				*disableRedirects,
 			)
 
-			// set a page size limit
-			if *maxSize != -1 {
-				c.MaxBodySize = *maxSize * 1024
-			}
+			// Setup callback logic for HTML elements.
+			setupCallbacks(
+				c,
+				urlToVisit,
+				results,
+				*inside,
+				*showSource,
+				*showWhere,
+				*showJSON,
+			)
 
-			// if -subs is present, use regex to filter out subdomains in scope.
-			if *subsInScope {
-				c.AllowedDomains = nil
-				c.URLFilters = []*regexp.Regexp{regexp.MustCompile(".*(\\.|\\/\\/)" + strings.ReplaceAll(hostname, ".", "\\.") + "((#|\\/|\\?).*)?")}
-			}
-
-			// If `-dr` flag provided, do not follow HTTP redirects.
-			if *disableRedirects {
-				c.SetRedirectHandler(func(req *http.Request, via []*http.Request) error {
-					return http.ErrUseLastResponse
-				})
-			}
-			// Set parallelism
-			c.Limit(&colly.LimitRule{DomainGlob: "*", Parallelism: *threads})
-
-			// Print every href found, and visit it
-			c.OnHTML("a[href]", func(e *colly.HTMLElement) {
-				link := e.Attr("href")
-				abs_link := e.Request.AbsoluteURL(link)
-				if strings.Contains(abs_link, url) || !*inside {
-
-					printResult(link, "href", *showSource, *showWhere, *showJson, results, e)
-					e.Request.Visit(link)
-				}
-			})
-
-			// find and print all the JavaScript files
-			c.OnHTML("script[src]", func(e *colly.HTMLElement) {
-				printResult(e.Attr("src"), "script", *showSource, *showWhere, *showJson, results, e)
-			})
-
-			// find and print all the form action URLs
-			c.OnHTML("form[action]", func(e *colly.HTMLElement) {
-				printResult(e.Attr("action"), "form", *showSource, *showWhere, *showJson, results, e)
-			})
-
-			// add the custom headers
-			if headers != nil {
-				c.OnRequest(func(r *colly.Request) {
-					for header, value := range headers {
-						r.Headers.Set(header, value)
-					}
-				})
-			}
-
-			if *proxy != "" {
-				// Skip TLS verification for proxy, if -insecure specified
-				c.WithTransport(&http.Transport{
-					Proxy:           http.ProxyURL(proxyURL),
-					TLSClientConfig: &tls.Config{InsecureSkipVerify: *insecure},
-				})
-			} else {
-				// Skip TLS verification if -insecure flag is present
-				c.WithTransport(&http.Transport{
-					TLSClientConfig: &tls.Config{InsecureSkipVerify: *insecure},
-				})
-			}
-
+			// Crawl with (or without) timeout.
 			if *timeout == -1 {
-				// Start scraping
-				c.Visit(url)
-				// Wait until threads are finished
+				// No timeout.
+				c.Visit(urlToVisit)
 				c.Wait()
 			} else {
-				finished := make(chan int, 1)
-
+				// With timeout.
+				done := make(chan struct{}, 1)
 				go func() {
-					// Start scraping
-					c.Visit(url)
-					// Wait until threads are finished
+					defer close(done)
+					c.Visit(urlToVisit)
 					c.Wait()
-					finished <- 0
 				}()
-
 				select {
-				case _ = <-finished: // the crawling finished before the timeout
-					close(finished)
-					continue
-				case <-time.After(time.Duration(*timeout) * time.Second): // timeout reached
-					log.Println("[timeout] " + url)
-					continue
-
+				case <-done:
+					// Completed before timeout.
+				case <-time.After(time.Duration(*timeout) * time.Second):
+					log.Println("[timeout]", urlToVisit)
 				}
 			}
+		}
 
+		// Check for scanner errors.
+		if err := sc.Err(); err != nil {
+			fmt.Fprintln(os.Stderr, "[Error] Reading standard input:", err)
 		}
-		if err := s.Err(); err != nil {
-			fmt.Fprintln(os.Stderr, "reading standard input:", err)
-		}
+
+		// Close the results channel to signal the output loop to end.
 		close(results)
 	}()
 
+	// Collect and print results from the channel.
+	printResults(results, *uniqueOnly)
+}
+
+// createCollector builds and returns a configured Colly Collector.
+func createCollector(
+	allowedDomains []string,
+	depth int,
+	maxSizeKB int,
+	insecure bool,
+	proxyURL *url.URL,
+	threads int,
+	subsInScope bool,
+	disableRedirects bool,
+) *colly.Collector {
+	c := colly.NewCollector(
+		colly.UserAgent("Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0"),
+		colly.Headers(headers),
+		colly.AllowedDomains(allowedDomains...),
+		colly.MaxDepth(depth),
+		colly.Async(true),
+	)
+
+	// If user has set a size limit.
+	if maxSizeKB != -1 {
+		c.MaxBodySize = maxSizeKB * 1024
+	}
+
+	// If user wants subdomains in scope, override AllowedDomains with a regex filter instead.
+	if subsInScope && len(allowedDomains) > 0 {
+		hostname := allowedDomains[0]
+		c.AllowedDomains = nil
+		// Use a regex that allows subdomains or the original domain name itself.
+		regexPattern := ".*(\\.|\\/\\/)" + strings.ReplaceAll(hostname, ".", "\\.") + "((#|\\/|\\?).*)?"
+		c.URLFilters = []*regexp.Regexp{regexp.MustCompile(regexPattern)}
+	}
+
+	// Optionally disable redirects.
+	if disableRedirects {
+		c.SetRedirectHandler(func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		})
+	}
+
+	// Parallelism limit.
+	c.Limit(&colly.LimitRule{
+		DomainGlob:  "*",
+		Parallelism: threads,
+	})
+
+	// Transport settings (proxy + TLS).
+	c.WithTransport(&http.Transport{
+		Proxy:           http.ProxyURL(proxyURL),
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+	})
+
+	// Additional custom headers on each request.
+	if headers != nil {
+		c.OnRequest(func(r *colly.Request) {
+			for headerKey, headerValue := range headers {
+				r.Headers.Set(headerKey, headerValue)
+			}
+		})
+	}
+
+	return c
+}
+
+// setupCallbacks configures the OnHTML callbacks, request visits, etc.
+func setupCallbacks(
+	c *colly.Collector,
+	baseURL string,
+	results chan string,
+	inside bool,
+	showSource bool,
+	showWhere bool,
+	showJSON bool,
+) {
+	// Follow 'href' links, optionally limited to inside path.
+	c.OnHTML("a[href]", func(e *colly.HTMLElement) {
+		link := e.Attr("href")
+		absoluteLink := e.Request.AbsoluteURL(link)
+		// If inside path only or if link is in base domain.
+		if strings.Contains(absoluteLink, baseURL) || !inside {
+			printResult(link, "href", showSource, showWhere, showJSON, results, e)
+			_ = e.Request.Visit(link)
+		}
+	})
+
+	// Find <script src="..."> links.
+	c.OnHTML("script[src]", func(e *colly.HTMLElement) {
+		printResult(e.Attr("src"), "script", showSource, showWhere, showJSON, results, e)
+	})
+
+	// Find <form action="..."> links.
+	c.OnHTML("form[action]", func(e *colly.HTMLElement) {
+		printResult(e.Attr("action"), "form", showSource, showWhere, showJSON, results, e)
+	})
+}
+
+// printResults handles the reading of results from a channel and output formatting.
+func printResults(results <-chan string, uniqueOnly bool) {
 	w := bufio.NewWriter(os.Stdout)
 	defer w.Flush()
-	urlsFound := false
-	if *unique {
+
+	var urlsFound bool
+
+	if uniqueOnly {
 		for res := range results {
 			if isUnique(res) {
 				fmt.Fprintln(w, res)
 				urlsFound = true
 			}
 		}
-	}
-	for res := range results {
-		fmt.Fprintln(w, res)
-		urlsFound = true
+	} else {
+		for res := range results {
+			fmt.Fprintln(w, res)
+			urlsFound = true
+		}
 	}
 
+	// If no URLs were found, show a helpful message.
 	if !urlsFound {
-		fmt.Fprintln(os.Stderr, "No URLs were found. This usually happens when a domain is specified (https://example.com), but it redirects to a subdomain (https://www.example.com). The subdomain is not included in the scope, so the no URLs are printed. In order to overcome this, either specify the final URL in the redirect chain or use the -subs option to include subdomains.")
+		fmt.Fprintln(os.Stderr, "No URLs were found. This might happen if the domain redirects to a subdomain not in scope. " +
+			"Try using the -subs option to include subdomains, or specify the final redirected URL.")
 	}
 }
 
-// parseHeaders does validation of headers input and saves it to a formatted map.
+// parseHeaders validates and stores raw headers (flag input) into a map.
 func parseHeaders(rawHeaders string) error {
-	if rawHeaders != "" {
-		if !strings.Contains(rawHeaders, ":") {
-			return errors.New("headers flag not formatted properly (no colon to separate header and value)")
+	if rawHeaders == "" {
+		return nil
+	}
+
+	if !strings.Contains(rawHeaders, ":") {
+		return errors.New("headers flag not formatted properly (no colon found to separate header and value)")
+	}
+
+	headers = make(map[string]string)
+
+	headerPairs := strings.Split(rawHeaders, ";;")
+	for _, header := range headerPairs {
+		var parts []string
+		// Attempt splitting on ": " first, then just ":" if that fails.
+		if strings.Contains(header, ": ") {
+			parts = strings.SplitN(header, ": ", 2)
+		} else if strings.Contains(header, ":") {
+			parts = strings.SplitN(header, ":", 2)
+		} else {
+			continue
 		}
 
-		headers = make(map[string]string)
-		rawHeaders := strings.Split(rawHeaders, ";;")
-		for _, header := range rawHeaders {
-			var parts []string
-			if strings.Contains(header, ": ") {
-				parts = strings.SplitN(header, ": ", 2)
-			} else if strings.Contains(header, ":") {
-				parts = strings.SplitN(header, ":", 2)
-			} else {
-				continue
-			}
-			headers[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if key == "" || value == "" {
+			return fmt.Errorf("invalid header detected: '%s'", header)
 		}
+		headers[key] = value
 	}
 	return nil
 }
 
-// extractHostname() extracts the hostname from a URL and returns it
+// extractHostname extracts the hostname from a URL, ensuring it's a valid absolute URL.
 func extractHostname(urlString string) (string, error) {
 	u, err := url.Parse(urlString)
-	if err != nil || !u.IsAbs() {
-		return "", errors.New("Input must be a valid absolute URL")
+	if err != nil {
+		return "", fmt.Errorf("failed to parse URL: %v", err)
 	}
-
+	if !u.IsAbs() {
+		return "", fmt.Errorf("URL is not absolute: %s", urlString)
+	}
 	return u.Hostname(), nil
 }
 
-// print result constructs output lines and sends them to the results chan
-func printResult(link string, sourceName string, showSource bool, showWhere bool, showJson bool, results chan string, e *colly.HTMLElement) {
-	result := e.Request.AbsoluteURL(link)
+// printResult constructs output lines and sends them to the results channel.
+func printResult(
+	link string,
+	sourceName string,
+	showSource bool,
+	showWhere bool,
+	showJSON bool,
+	results chan string,
+	e *colly.HTMLElement,
+) {
+	absLink := e.Request.AbsoluteURL(link)
+	if absLink == "" {
+		return
+	}
+
 	whereURL := e.Request.URL.String()
-	if result != "" {
-		if showJson {
-			where := ""
-			if showWhere {
-				where = whereURL
-			}
-			bytes, _ := json.Marshal(Result{
-				Source: sourceName,
-				URL:    result,
-				Where:  where,
-			})
-			result = string(bytes)
-		} else if showSource {
+	result := absLink
+
+	// If JSON output.
+	if showJSON {
+		where := ""
+		if showWhere {
+			where = whereURL
+		}
+		bytes, _ := json.Marshal(Result{
+			Source: sourceName,
+			URL:    absLink,
+			Where:  where,
+		})
+		result = string(bytes)
+	} else {
+		// Add source label.
+		if showSource {
 			result = "[" + sourceName + "] " + result
 		}
-
-		if showWhere && !showJson {
+		// Add where it was found if requested (and not JSON).
+		if showWhere {
 			result = "[" + whereURL + "] " + result
 		}
-
-		// If timeout occurs before goroutines are finished, recover from panic that may occur when attempting writing to results to closed results channel
-		defer func() {
-			if err := recover(); err != nil {
-				return
-			}
-		}()
-		results <- result
 	}
+
+	// Recover from any panic if channel is closed (e.g. due to timeout).
+	defer func() {
+		if r := recover(); r != nil {
+			return
+		}
+	}()
+	results <- result
 }
 
-// returns whether the supplied url is unique or not
-func isUnique(url string) bool {
-	_, present := sm.Load(url)
-	if present {
+// isUnique checks if the provided URL has been seen before.
+func isUnique(urlStr string) bool {
+	_, found := sm.Load(urlStr)
+	if found {
 		return false
 	}
-	sm.Store(url, true)
+	sm.Store(urlStr, true)
 	return true
 }


### PR DESCRIPTION
feat: improve error handling, user-friendliness, and scalability

- Validate thread count; reset to default (8) if invalid
- Check for malformed or empty proxy URLs, exit with meaningful errors
- Refactor collector creation into createCollector for better readability
- Add setupCallbacks to modularize OnHTML callbacks
- Use select block with a timeout channel to gracefully handle timeouts
- Log scanner errors from stdin and display helpful hints
- Provide detailed error messages when URLs are not found or out of scope
- Recover from potential channel closure (timeout) in printResult